### PR TITLE
:scream: Do not enforce renaming props for destructuring

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -51,7 +51,7 @@ module.exports = {
         object: true,
       },
       {
-        enforceForRenamedProperties: true,
+        enforceForRenamedProperties: false,
       },
     ],
     'sort-keys': [

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+0.23.0 / 2019-10-10
+===================
+- Do not enforce destructuring option for renamed properties 
+
 0.22.0 / 2019-10-08
 ===================
 - Disallow empty lines at BOF and EOF

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-nhsuk",
-  "version": "0.22.0",
+  "version": "0.23.0",
   "description": "ESLint config. Primarily intended for use within NHSUK projects.",
   "main": ".eslintrc.js",
   "scripts": {


### PR DESCRIPTION
Enforcing destructuring option for renamed properties turns out to not
be a great option to have turned on. After implementing the rules in
some other projects it has been decided to not force the option.